### PR TITLE
Replace `syscall' package by `golang.org/x/sys/unix'

### DIFF
--- a/cmd/sftpplease/scp/scp.go
+++ b/cmd/sftpplease/scp/scp.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"path"
 	"strings"
-	"syscall"
 
 	"github.com/andrewchambers/sftpplease/vfs"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -220,8 +220,8 @@ func sinkDir(parent, line string, times *FileTimes) error {
 	var pendErrs []error
 	if times != nil {
 		// XXX: VFS has no utimes api.
-		//t := []syscall.Timeval{times.Atime, times.Mtime}
-		//if err := syscall.Utimes(name, t); err != nil {
+		//t := []unix.Timeval{times.Atime, times.Mtime}
+		//if err := unix.Utimes(name, t); err != nil {
 		//	pendErrs = append(pendErrs, err)
 		//}
 	}
@@ -284,8 +284,8 @@ func sinkFile(name, line string, times *FileTimes) error {
 		}
 	}
 	if times != nil {
-		if err := syscall.Utimes(name,
-			[]syscall.Timeval{times.Atime, times.Mtime}); err != nil {
+		if err := unix.Utimes(name,
+			[]unix.Timeval{times.Atime, times.Mtime}); err != nil {
 
 			pendErrs = append(pendErrs, err)
 		}
@@ -457,7 +457,7 @@ func sendAttr(st os.FileInfo) error {
 	mtime := st.ModTime().Unix()
 	atime := int64(0)
 
-	if sysStat, ok := st.Sys().(*syscall.Stat_t); ok {
+	if sysStat, ok := st.Sys().(*unix.Stat_t); ok {
 		atime, _ = sysStat.Atim.Unix()
 	}
 
@@ -558,8 +558,8 @@ func usage() {
 }
 
 type FileTimes struct {
-	Atime syscall.Timeval
-	Mtime syscall.Timeval
+	Atime unix.Timeval
+	Mtime unix.Timeval
 }
 
 type FatalError string

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 // indirect
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
 	golang.org/x/oauth2 v0.0.0-20190212230446-3e8b2be13635 // indirect
-	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 )
+
+go 1.13


### PR DESCRIPTION
The build failed on FreeBSD with:

    scp/scp.go:461:21: sysStat.Atim undefined (type *syscall.Stat_t has no field or method Atim)

As `syscall` package is deprecated according to the official
documentation, replace it by the `golang.org/x/sys/unix` package. This
also fixes the build on FreeBSD.